### PR TITLE
changes for docutils 0.10

### DIFF
--- a/nbconvert.py
+++ b/nbconvert.py
@@ -631,7 +631,7 @@ def rst2simplehtml(infile):
     # simplest html I could find.  This should help in making it easier to
     # paste into the blogspot html window, though I'm still having problems
     # with linebreaks there...
-    cmd_template = ("rst2html --link-stylesheet --no-xml-declaration "
+    cmd_template = ("rst2html.py --link-stylesheet --no-xml-declaration "
                     "--no-generator --no-datestamp --no-source-link "
                     "--no-toc-backlinks --no-section-numbering "
                     "--strip-comments ")

--- a/rst2ipynblib/__init__.py
+++ b/rst2ipynblib/__init__.py
@@ -14,11 +14,11 @@ import re
 import urllib
 import docutils
 from docutils import frontend, nodes, utils, writers, languages, io
-from docutils.error_reporting import SafeString
+from docutils.util.error_reporting import SafeString
 from docutils.transforms import writer_aux
-from docutils.math import unichar2tex, pick_math_environment
-from docutils.math.latex2mathml import parse_latex_math
-from docutils.math.math2html import math2html
+from docutils.util.math import unichar2tex, pick_math_environment
+from docutils.util.math.latex2mathml import parse_latex_math
+from docutils.util.math.math2html import math2html
 from IPython.nbformat import current as nbformat
 
 


### PR DESCRIPTION
not sure whether this is a known problem or not, but
I had to make a few changes to get 

./nbconvert.py --format rst test.ipynb

and 

./nbconvert.py --format html test.ipynb

working with the current docutils branch at sourceforge

cheers, Phil Austin
